### PR TITLE
bugfix: ファイルクリーンアップでブログの添付ファイルが削除されるバグ修正

### DIFF
--- a/Model/CleanUp.php
+++ b/Model/CleanUp.php
@@ -475,12 +475,10 @@ class CleanUp extends CleanUpAppModel {
 		$fieldsArray = explode(self::FIELD_DELIMITER, $fields);
 		foreach ($fieldsArray as $field) {
 			$field = trim($field);
-			$checkConditions[] = array(
-				'OR' => array(
-					array($this->$model->alias . '.' . $field . ' LIKE' => '%' . $checkFileUrl . '%'),
-					array($this->$model->alias . '.' . $field . ' LIKE' => '%' . $checkImageUrl . '%'),
-				),
-			);
+			$checkConditions['OR'][]
+					= array($this->$model->alias . '.' . $field . ' LIKE' => '%' . $checkFileUrl . '%');
+			$checkConditions['OR'][]
+					= array($this->$model->alias . '.' . $field . ' LIKE' => '%' . $checkImageUrl . '%');
 		}
 
 		// 最新とアクティブを取得する条件（多言語も取得される）


### PR DESCRIPTION
https://github.com/NetCommons3/NetCommons3/issues/1538

修正内容
https://www.netcommons.org/bbses/bbs_articles/view/778/70d762af0f36318a3563974188845393?frame_id=199#!#bbs-article-531
```
/app/Plugin/CleanUp/Model/CleanUp.php　の476行目から484行目の検索条件でBODY1、BODY2の条件がANDで検索されてしまっています。ですので検索カウントが0件となり使用していないと判断され削除されてしまっています。

ついては、BODY1・BODY2の条件もORになるように$checkConditionsを作る必要があります。
```